### PR TITLE
mastodon: init at 6.2.1

### DIFF
--- a/charts/mastodon/metadata.yaml
+++ b/charts/mastodon/metadata.yaml
@@ -1,0 +1,4 @@
+---
+registry: https://github.com/mastodon/chart
+chart: mastodon
+version: 6.2.1


### PR DESCRIPTION
I currently maintain my own, I would like not to. References for upstream eventual OCI: 

https://github.com/mastodon/chart/pull/54
https://github.com/mastodon/chart/issues/129