### PR TITLE
Update README with enhanced verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ spec:
   url: oci://ghcr.io/home-operations/charts-mirror/${CHART}
   verify:
     provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token.actions.githubusercontent.com$"
+        subject: "^https://github.com/home-operations/charts-mirror.*$"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
The yaml proposal only checks the existence of a cosign signature, but not the origination.
This enhances the proposal so that it has to originate from the project.

matchOIDCIdentity:
      - issuer: "^https://token.actions.githubusercontent.com$"
        subject: "^https://github.com/home-operations/charts-mirror.*$"