### PR TITLE
feat: Add mongodb-community-operator

### DIFF
--- a/charts/mongodb-community-operator/metadata.yaml
+++ b/charts/mongodb-community-operator/metadata.yaml
@@ -1,0 +1,4 @@
+---
+registry: https://mongodb.github.io/helm-charts
+chart: community-operator
+version: 0.12.0


### PR DESCRIPTION
https://github.com/mongodb/helm-charts/issues/387

This will create an oci artifact at `/community-operator`, as that's the chart name, but I put it in the folder `mongodb-community-operator` to help identify it.