### PR TITLE
chore: update volsync 0.13.0-rc.2

### DIFF
--- a/charts/volsync/metadata.yaml
+++ b/charts/volsync/metadata.yaml
@@ -1,4 +1,4 @@
 ---
 registry: https://backube.github.io/helm-charts/
 name: volsync
-version: 0.12.1
+version: 0.13.0-rc.2


### PR DESCRIPTION
Manual trigger to bump volsync to the latest RC