### PR TITLE
feat: add fluent-bit

### DIFF
--- a/apps/fluent-bit/metadata.yaml
+++ b/apps/fluent-bit/metadata.yaml
@@ -1,0 +1,5 @@
+---
+chartRegistry: https://fluent.github.io/helm-charts
+chartName: fluent-bit
+chartVersion: 0.53.0
+artifactName: fluent-bit


### PR DESCRIPTION
First time contributing to add fluent-bit. There was an OCI issue open a year ago in the upstream chart repo https://github.com/fluent/helm-charts/issues/550 by another user. 