### PR TITLE
feat: add infisical-standalone-postgres

### DIFF
--- a/.github/workflows/app-builder.yaml
+++ b/.github/workflows/app-builder.yaml
@@ -116,7 +116,14 @@ jobs:
           tag=$(jq -r '.git.tag' <<< "$SOURCE")
           git clone --depth 1 --branch "$tag" "$repository" ./git-src
           mkdir -p ./src
-          cp -r "./git-src/${path}" "./src/$(basename "$path")"
+          chart="./src/$(basename "$path")"
+          cp -r "./git-src/${path}" "$chart"
+          # A git chart isn't packaged with its dependencies, so vendor them before
+          # packaging. Register any http(s) dependency repos (helm requires it); OCI
+          # (oci://) dependencies resolve directly.
+          yq -r '.dependencies[] | select(.repository // "" | test("^http")) | .name + " " + .repository' "$chart/Chart.yaml" \
+            | while read -r name repo; do helm repo add "$name" "$repo"; done
+          helm dependency build "$chart"
 
       - name: Override Chart Name
         run: |

--- a/apps/infisical-standalone-postgres/metadata.yaml
+++ b/apps/infisical-standalone-postgres/metadata.yaml
@@ -1,0 +1,7 @@
+---
+artifactName: infisical-standalone-postgres
+source:
+  git:
+    repository: https://github.com/Infisical/infisical
+    path: ./helm-charts/infisical-standalone-postgres
+    tag: v0.159.29


### PR DESCRIPTION
## What

Adds the `infisical-standalone-postgres` chart (git-sourced) **plus** the builder support needed to package git charts that have dependencies.

**Chart** — `apps/infisical-standalone-postgres/metadata.yaml`, matching the existing `agent-sandbox` git pattern:

- repository `github.com/Infisical/infisical`, path `./helm-charts/infisical-standalone-postgres`, tag `v0.159.29` → published to GHCR as OCI `0.159.29`.

**Builder** — `app-builder.yaml`: a git chart ships its dependency *declarations* but not the vendored `charts/`, so `helm package` fails on them. The git fetch step now adds any classic `http(s)` dependency repos and runs `helm dependency build` before packaging (OCI deps resolve directly). It's a no-op for git charts without dependencies, and helm-sourced charts are untouched.

`infisical-standalone-postgres` declares `postgresql` + `redis` (bitnami OCI) and `ingress-nginx` (https) — the first git-sourced chart here with dependencies, which is what surfaced the gap.

## Validated locally (helm 4.2.0, same version CI uses)

```text
# packaging the raw git chart (today's behavior):
Error: found in Chart.yaml, but missing in charts/ directory: ingress-nginx, postgresql, redis

# with the fix — repo-add the http dep + helm dependency build (OCI deps pull directly):
Pulled: registry-1.docker.io/bitnamicharts/postgresql:14.1.10
Pulled: registry-1.docker.io/bitnamicharts/redis:18.14.1
…charts/ now has ingress-nginx, postgresql, redis →
Successfully packaged chart and saved it to: …/infisical-standalone-0.159.29.tgz
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
