### PR TITLE
feat(renovate): auto-merge git-sourced mirrors

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -25,8 +25,8 @@
   ],
   packageRules: [
     {
-      description: "Auto-merge Helm Charts",
-      matchDatasources: ["helm"],
+      description: "Auto-merge mirrored charts (Helm + git sources)",
+      matchDatasources: ["helm", "git-tags"],
       automerge: true,
       automergeType: "pr",
       matchUpdateTypes: ["major", "minor", "patch"],

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -25,7 +25,7 @@
   ],
   packageRules: [
     {
-      description: "Auto-merge mirrored charts (Helm + git sources)",
+      description: "Auto-merge mirrored charts",
       matchDatasources: ["helm", "git-tags"],
       automerge: true,
       automergeType: "pr",


### PR DESCRIPTION
Git-sourced apps (e.g. `infisical-standalone-postgres`) are picked up by the "Process git-sourced charts" regex custom manager with datasource **`git-tags`**, but the automerge rule matched only datasource **`helm`** — so their update PRs (like #567, `infisical v0.161.1 → v0.161.2`) never auto-merged.

Fix: add `git-tags` to the rule's `matchDatasources`:
```json5
matchDatasources: ["helm", "git-tags"]
```
git-sourced mirrors now auto-merge on the same terms as the Helm ones (`automergeType: pr`, `ignoreTests: false` — the mirror build/test still gates the merge). Validated with `renovate-config-validator --strict`.

(Note: there's no `vendir` manager here — both sources are `custom.regex` managers distinguished by datasource, so matching the datasource is the right lever.) After merge, Renovate's next run should auto-merge #567.