### PR TITLE
feat: add bifrost

### DIFF
--- a/apps/bifrost/metadata.yaml
+++ b/apps/bifrost/metadata.yaml
@@ -1,0 +1,6 @@
+---
+artifactName: bifrost
+source:
+  helm:
+    registry: https://maximhq.github.io/bifrost/helm-charts
+    version: 2.1.24


### PR DESCRIPTION
## Overview

Adding Bifrost (maximhq/bifrost LLM gateway) as an OCI mirror.

## Additional information

Upstream re-uploads chart release assets without regenerating `index.yaml`, so the recorded digest no longer matches the served `.tgz` (e.g. `2.1.24`: index `1366846…` vs tarball `8c0fa46…`). This breaks every digest-verifying consumer (Flux source-controller, flate, konflate); an OCI mirror sidesteps it.

Upstream tracking issue: https://github.com/maximhq/bifrost/issues/3891

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES — used Claude Code to prepare the metadata file and PR.
