### PR TITLE
style: indent markdown at 2 to match embedded yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = false
 
 [Dockerfile]

--- a/README.md
+++ b/README.md
@@ -23,34 +23,34 @@ helm install ${RELEASE_NAME} --namespace ${NAMESPACE} oci://ghcr.io/home-operati
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: OCIRepository
 metadata:
-    name: ${CHART_NAME}
-    namespace: ${NAMESPACE}
+  name: ${CHART_NAME}
+  namespace: ${NAMESPACE}
 spec:
-    interval: 1h
-    layerSelector:
-        mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-        operation: copy
-    ref:
-        tag: ${CHART_VERSION}
-    url: oci://ghcr.io/home-operations/charts-mirror/${CHART_NAME}
-    verify:
-        provider: cosign
-        matchOIDCIdentity:
-            - issuer: ^https://token.actions.githubusercontent.com$
-              subject: ^https://github.com/home-operations/charts-mirror.*$
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: ${CHART_VERSION}
+  url: oci://ghcr.io/home-operations/charts-mirror/${CHART_NAME}
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token.actions.githubusercontent.com$
+        subject: ^https://github.com/home-operations/charts-mirror.*$
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-    name: ${RELEASE_NAME}
-    namespace: ${NAMESPACE}
+  name: ${RELEASE_NAME}
+  namespace: ${NAMESPACE}
 spec:
-    interval: 1h
-    chartRef:
-        kind: OCIRepository
-        name: ${CHART_NAME}
-        namespace: ${NAMESPACE}
-    values:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: ${CHART_NAME}
+    namespace: ${NAMESPACE}
+  values:
 ...
 ```
 
@@ -60,48 +60,48 @@ To add a new chart to this repository:
 
 1. **Check for an existing OCI Helm Chart**
 
-    Confirm that the application you want to add does **not** already provide an official OCI Helm Chart.
+   Confirm that the application you want to add does **not** already provide an official OCI Helm Chart.
 
 2. **Create a chart directory**
 
-    Make a new directory under `apps/` named after the chart.
+   Make a new directory under `apps/` named after the chart.
 
 3. **Add chart metadata**
 
-    Inside the new directory, create a `metadata.yaml` file. The `source:` block tells the builder where to fetch the chart from — set exactly one of `helm` or `git`.
+   Inside the new directory, create a `metadata.yaml` file. The `source:` block tells the builder where to fetch the chart from — set exactly one of `helm` or `git`.
 
-    **Helm-sourced** (the upstream publishes a traditional Helm repository):
+   **Helm-sourced** (the upstream publishes a traditional Helm repository):
 
-    ```yaml
-    ---
-    artifactName: <name of the published chart>
-    source:
-        helm:
-            registry: <upstream Helm repository URL>
-            version: <upstream chart version>
-            # chart: <upstream chart name>   # optional, defaults to artifactName
-    ```
+   ```yaml
+   ---
+   artifactName: <name of the published chart>
+   source:
+     helm:
+       registry: <upstream Helm repository URL>
+       version: <upstream chart version>
+       # chart: <upstream chart name>   # optional, defaults to artifactName
+   ```
 
-    **Git-sourced** (the upstream ships chart manifests in a git repository but does not publish a Helm chart):
+   **Git-sourced** (the upstream ships chart manifests in a git repository but does not publish a Helm chart):
 
-    ```yaml
-    ---
-    artifactName: <name of the published chart>
-    source:
-        git:
-            repository: <upstream git repository URL>
-            path: <path to the chart directory within the repository>
-            tag: <git tag to clone>
-    ```
+   ```yaml
+   ---
+   artifactName: <name of the published chart>
+   source:
+     git:
+       repository: <upstream git repository URL>
+       path: <path to the chart directory within the repository>
+       tag: <git tag to clone>
+   ```
 
-    The chart is published to GHCR under `artifactName`, with any leading `v` stripped from `source.helm.version` (or `source.git.tag`) so the OCI tag is SemVer-clean. The upstream version/tag is still fetched verbatim.
+   The chart is published to GHCR under `artifactName`, with any leading `v` stripped from `source.helm.version` (or `source.git.tag`) so the OCI tag is SemVer-clean. The upstream version/tag is still fetched verbatim.
 
 4. **Request upstream OCI support**
 
-    If the upstream project does not yet publish OCI Helm Charts (or any Helm chart at all, for git-sourced entries), open an issue in their application or chart repository requesting OCI Helm Chart support.
+   If the upstream project does not yet publish OCI Helm Charts (or any Helm chart at all, for git-sourced entries), open an issue in their application or chart repository requesting OCI Helm Chart support.
 
 5. **Submit a pull request**
 
-    Open a PR in this repository:
-    - Include the link to the upstream issue (from step 4) in the PR description.
-    - Ensure your PR only adds the new chart directory and metadata.
+   Open a PR in this repository:
+   - Include the link to the upstream issue (from step 4) in the PR description.
+   - Ensure your PR only adds the new chart directory and metadata.


### PR DESCRIPTION
Mirrors the canonical change in home-operations/.github#37.

`oxfmt` applies a markdown file's `tabWidth` to embedded code blocks. With `[*.md] indent_size = 4`, yaml examples inside the docs get rewritten to 4-space indentation while the yaml files they document stay at 2 under `[*] indent_size = 2`. Anyone copying from the README gets the wrong style. This sets `[*.md] indent_size = 2`.

The reformat is cosmetic: verified across the org that rendered markdown structure is unchanged (no new indented-code-blocks, identical list nesting) and that embedded yaml parses to identical values, block scalars included. Reindented with the repo's pinned oxfmt.