### PR TITLE
feat: add harbor

### DIFF
--- a/apps/harbor/metadata.yaml
+++ b/apps/harbor/metadata.yaml
@@ -1,0 +1,6 @@
+---
+artifactName: harbor
+source:
+  helm:
+    registry: https://helm.goharbor.io
+    version: 1.19.1


### PR DESCRIPTION
## Overview

Adding Harbor (goharbor/harbor-helm) as an OCI mirror.

## Additional information

Upstream's release workflow pushes to `oci://ghcr.io/${{ github.actor }}`, so charts land in whichever maintainer pushed the tag — `ghcr.io/goharbor/harbor` holds only a `test` tag. The Docker Hub push 401s. https://github.com/goharbor/harbor-helm/pull/2294 fixes both but has sat unreviewed since January.

Upstream tracking issue: https://github.com/goharbor/harbor-helm/issues/2265

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES — used Claude Code to prepare the metadata file and PR.
