### PR TITLE
fix(ci): gate every job behind Build Success

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -69,6 +69,8 @@ jobs:
     if: ${{ !cancelled() }}
     needs:
       - "build"
+      - "changed"
+      - "prepare"
     name: Build Success
     runs-on: ubuntu-24.04
     permissions: {}


### PR DESCRIPTION
## Overview

`Build Success` did not depend on every job in the workflow — only on the ones the
changed-files detection feeds.

| repo | jobs missing from `needs` |
| --- | --- |
| containers | `prepare` |
| charts-mirror | `prepare`, `changed` |
| k8s-schemas | `changed` |

## Why it matters now

When a job's dependency **fails**, the dependent job is **skipped**, not failed.
The gate only fails on the literal string `failure`:

```yaml
if: ${{ contains(needs.*.result, 'failure') }}
```

So a failed `prepare`/`changed` produced `skipped` dependents, no `failure`
anywhere in `needs.*.result`, and a **green** `Build Success`.

That was harmless while nothing required the check. Since
home-operations/.github#46 it is the required status check on `main`, so the gap
let a run with broken detection merge.

## The fix keeps skip tolerance

Adding the jobs to `needs` does not change how skips are treated — the gate still
runs on `!cancelled()` and still passes when its dependencies are *skipped*. That
is deliberate and load-bearing: it is what keeps release-please pull requests
mergeable when every job legitimately skips.

The difference is that a genuine **failure** in those jobs now appears in
`needs.*.result` and turns the gate red.

## Note

The repos consolidated into `ci.yaml` never had this gap — that generator gates
every job and the check was asserted at build time, which is why `helm-charts`
(same changed-files shape) is unaffected. These three kept their original
`pull-request.yaml` and so were never re-verified.

Found by an audit of all 24 repos after enforcement went live.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES — change and description written by an AI agent (Claude Code) under maintainer direction.
