### PR TITLE
fix: pass the app name to github-script through the environment

### DIFF
--- a/.github/actions/app-exists/action.yaml
+++ b/.github/actions/app-exists/action.yaml
@@ -19,9 +19,11 @@ runs:
     - name: Application Exists
       id: application
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        APP_NAME: ${{ inputs.app }}
       with:
         script: |
-          const applicationName = '${{ inputs.app }}';
+          const applicationName = process.env.APP_NAME;
 
           const { data: user } = await github.rest.users.getByUsername({
               username: context.repo.owner,


### PR DESCRIPTION
zizmor flags `.github/actions/app-exists/action.yaml` with `template-injection` (high severity, high confidence).

`${{ inputs.app }}` was interpolated into the `script:` body before JavaScript parsed it, so the input was source code rather than a value — an app name containing a quote would break out of the string literal and run with the workflow's token. Reading it from `process.env` instead makes it a plain string.

Not currently exploitable: the only caller is `app-builder.yaml` and the value comes from this repository's own app list, not from a fork. Fixing it anyway since it costs two lines, and once #684 lands this fails CI.

zizmor is clean on the file after the change.