### PR TITLE
ci: drop unused checkout from deprecate-app merge job

### DIFF
--- a/.github/workflows/deprecate-app.yaml
+++ b/.github/workflows/deprecate-app.yaml
@@ -80,11 +80,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Generate Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token


### PR DESCRIPTION
The `merge` job in `deprecate-app.yaml` checks out the repository and then never touches the workspace: it mints an app token and merges the pull request through `actions/github-script`. Removing the step.

Every other checkout in this repo stays. The `plan` job validates and deletes `./apps/<chart>`, the `changed` jobs run `yq` over `apps/**/metadata.yaml`, `build` needs the tree for mise and chart packaging, and `workflow-lint` lints the workflow files themselves.

Split out from the `$/` self-repository work so this piece can merge on its own.