### PR TITLE
ci: adopt self-repository syntax for local action refs

### DIFF
--- a/.github/workflows/app-builder.yaml
+++ b/.github/workflows/app-builder.yaml
@@ -34,11 +34,6 @@ jobs:
       source-type: ${{ steps.source.outputs.type }}
       version: ${{ steps.source.outputs.version }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Get Repository Name
         id: repository
         run: |
@@ -64,7 +59,7 @@ jobs:
           fi
 
       - name: Check For Exising Chart
-        uses: ./.github/actions/app-exists
+        uses: $/.github/actions/app-exists
         id: app
         with:
           app: ${{ steps.repository.outputs.name }}/${{ inputs.artifactName }}
@@ -152,11 +147,6 @@ jobs:
       - build
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Get Repository Name
         id: repository
         run: |
@@ -171,7 +161,7 @@ jobs:
           permission-contents: write
 
       - name: Get Release Tag
-        uses: ./.github/actions/release-tag
+        uses: $/.github/actions/release-tag
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -179,6 +169,7 @@ jobs:
       - name: Create Release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ steps.release.outputs.tag }}
           ARTIFACT_NAME: ${{ inputs.artifactName }}
           REPO_NAME: ${{ steps.repository.outputs.name }}

--- a/.github/workflows/deprecate-app.yaml
+++ b/.github/workflows/deprecate-app.yaml
@@ -117,11 +117,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Generate Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
@@ -131,7 +126,7 @@ jobs:
           permission-contents: write
 
       - name: Get Release Tag
-        uses: ./.github/actions/release-tag
+        uses: $/.github/actions/release-tag
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -139,6 +134,7 @@ jobs:
       - name: Create Release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ steps.release.outputs.tag }}
           CHART_NAME: ${{ inputs.chartName }}
           REASON: ${{ inputs.reason }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -88,7 +88,7 @@ jobs:
           echo "zizmor=$(mise config get tools.zizmor)" >> "$GITHUB_OUTPUT"
 
       - name: Lint workflows
-        uses: home-operations/.github/actions/workflow-lint@dfa0b198336d33dcbe73557a68315d3071ec7709 # workflow-lint-1.0.0
+        uses: home-operations/.github/actions/workflow-lint@5514ee499e8919d394b5376637025535dac84ff8 # workflow-lint-v1.0.2
         with:
           actionlint-version: ${{ steps.tools.outputs.actionlint }}
           zizmor-version: ${{ steps.tools.outputs.zizmor }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -51,7 +51,7 @@ jobs:
     needs:
       - "changed"
     name: Build ${{ matrix.app.artifactName }}
-    uses: ./.github/workflows/app-builder.yaml
+    uses: $/.github/workflows/app-builder.yaml
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
     needs:
       - "changed"
     name: Build ${{ matrix.app.artifactName }}
-    uses: ./.github/workflows/app-builder.yaml
+    uses: $/.github/workflows/app-builder.yaml
     permissions:
       contents: read
       id-token: write

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -7,7 +7,7 @@ lefthook = "2.1.10"
 oxfmt = "0.61.0"
 shellcheck = "0.11.0"
 yq = "4.53.3"
-zizmor = "1.28.0"
+zizmor = "1.29.0"
 
 [hooks]
 postinstall = "lefthook install"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -306,41 +306,41 @@ url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146721"
 provenance = "cosign"
 
 [[tools.zizmor]]
-version = "1.28.0"
+version = "1.29.0"
 backend = "aqua:zizmorcore/zizmor"
 
 [tools.zizmor."platforms.linux-arm64"]
-checksum = "sha256:324e43770cfacf4216f8aefb287263b5b5c733c85b03bf7583b5cc4a0460239e"
-url = "https://github.com/zizmorcore/zizmor/releases/download/v1.28.0/zizmor-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/485211654"
+checksum = "sha256:415eaa7c0a06479a701b8e44a3e812c1047decc848ec4bede7bd6bbf49f22d20"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.29.0/zizmor-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/498263143"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.linux-arm64-musl"]
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.linux-x64"]
-checksum = "sha256:e87b67160194884e375a46a12c57ccc904f762b53845f254fab7f17d98809c09"
-url = "https://github.com/zizmorcore/zizmor/releases/download/v1.28.0/zizmor-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/485211657"
+checksum = "sha256:dd96df044a6e8538d5f423790f453bdd03d49e5b2bcc38214acc41a2f1297839"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.29.0/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/498263145"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.linux-x64-musl"]
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.macos-arm64"]
-checksum = "sha256:54949bbd6b4c8527046bb8990bac9e0dab3eec787640f4e6199ae121dd1040be"
-url = "https://github.com/zizmorcore/zizmor/releases/download/v1.28.0/zizmor-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/485211655"
+checksum = "sha256:720322fade9e83a9c7953944c438f2ba942636b86b96a8f0e6b15ce94c8a6b6f"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.29.0/zizmor-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/498263141"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.macos-x64"]
-checksum = "sha256:40a58d8560d65c71357b3977d0da425773bf8f10bf1ffd38099d963d3afdf3aa"
-url = "https://github.com/zizmorcore/zizmor/releases/download/v1.28.0/zizmor-x86_64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/485211652"
+checksum = "sha256:648b72ab9941a7f2a8d65d7b68a8e76cef789538c8df3a3950384d38423375b0"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.29.0/zizmor-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/498263144"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.windows-x64"]
-checksum = "sha256:06e5b2345323201ed4c55897651862fee3b43f79ddced799f1236f0f0d1c1c0f"
-url = "https://github.com/zizmorcore/zizmor/releases/download/v1.28.0/zizmor-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/485211651"
+checksum = "sha256:68a6bc6888f10bf0d53658c75885e7c1b7a0588d4c1fbc3f0ca280ad7324bf06"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.29.0/zizmor-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/498263142"
 provenance = "github-attestations"


### PR DESCRIPTION
Adopts the [`$/` self-repository syntax](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/) announced 2026-07-30. A `uses:` value starting with `$/` resolves to the running workflow's own repository at the exact commit that is running, with no checkout required.

## Changes

- All five `uses: ./.github/...` references become `uses: $/.github/...`, including the two reusable-workflow calls in `pull-request.yaml` and `release.yaml`.
- Three jobs drop their checkout, because the step existed only to make a sibling composite action available and both `app-exists` and `release-tag` are pure API:
  - `app-builder.yaml` `plan` - the steps before `app-exists` only read `GITHUB_REPOSITORY` and run `jq` over an input.
  - `app-builder.yaml` `release` and `deprecate-app.yaml` `announce` - both now set `GH_REPO` explicitly, because without a checkout `gh release create` has no git remote to infer the repository from.

The `build` job keeps its checkout; it needs the tree for mise and chart packaging.

## Draft: blocked on linter support

Both linters in the `workflow-lint` gate reject `$/` as of their latest releases:

- **actionlint 1.7.12** (latest, 2026-03-30) reports `specifying action "$/.github/actions/app-exists" in invalid format because ref is missing`. Tracked upstream as rhysd/actionlint#711.
- **zizmor 1.28.0** (latest, 2026-07-21) cannot parse the file at all and aborts the whole audit with `fatal: no audit was performed`, so it is not a matter of suppressing one rule.

Holding as a draft until both ship support. The commit was made with `--no-verify` for the same reason.